### PR TITLE
Fix a mistake in settings/tables

### DIFF
--- a/settings/tables.tex
+++ b/settings/tables.tex
@@ -1,6 +1,6 @@
 % Table layout
 \setlength{\tabcolsep}{0.5em} % for the horizontal padding
-{\renewcommand{\arraystretch}{1.2} % for the vertical padding
+\renewcommand{\arraystretch}{1.2} % for the vertical padding
 
 % Table captions
 \usepackage{caption} 


### PR DESCRIPTION
There is a mistake in `settings/tables.tex` where a new group is created and never closed. Newer versions of pdfTeX do not allow loading classes or packages in groups, and thus the compilation fails.
This PR fixes this tiny mistake.